### PR TITLE
Make sure oc receives only lowercase object names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
         oc login --token=${{ inputs.oc_token }} --server=${{ inputs.oc_server }}
         oc project ${{ inputs.oc_namespace }}
 
-        # Bug - Docker hates org/repo names with capitals
+        # Bug - OpenShift hates images with capitals in org/repo names
         PARAMETERS="${{ inputs.parameters }}"
         REPO_LOW=$( echo ${{ inputs.repository }} | tr '[:upper:]' '[:lower:]' )
         if [ "${{ inputs.repository }}" != "${REPO_LOW}" ]; then

--- a/action.yml
+++ b/action.yml
@@ -53,8 +53,15 @@ runs:
         oc login --token=${{ inputs.oc_token }} --server=${{ inputs.oc_server }}
         oc project ${{ inputs.oc_namespace }}
 
+        # Bug - Docker hates org/repo names with capitals
+        PARAMETERS="${{ inputs.parameters }}"
+        REPO_LOW=$( echo ${{ inputs.repository }} | tr '[:upper:]' '[:lower:]' )
+        if [ "${{ inputs.repository }}" != "${REPO_LOW}" ]; then
+          PARAMETERS=$( echo ${{ inputs.parameters }} | sed "s ${{ inputs.repository }} ${REPO_LOW} ")
+        fi
+
         # Process template, consuming variables/parameters
-        TEMPLATE=$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)
+        TEMPLATE=$(oc process -f ${{ inputs.file }} ${PARAMETERS} --local)
 
         # ImageStream and DeploymentConfig names
         IS=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"ImageStream\") | .metadata.name")


### PR DESCRIPTION
In deployer action oc is choking on uppercase letters, like in my GitHub ID.  Change action to ensure lowercase.

```
The ImageStream "testing-5-backend" is invalid: spec.tags[latest].from.name: Invalid value: "ghcr.io/DerekRoberts/testing/backend:5": repository name must be lowercase
```