### PR TITLE
Stop using curl -I, unrelated head issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
         echo -e "\n${URL}"
         # Curl and verify, max 3 attempts
         for (( i=0; i<3; i++ )); do
-          HTTP_CODE=$(curl -ILso /dev/null -w "%{http_code}" "${URL}")
+          HTTP_CODE=$(curl -Lso /dev/null -w "%{http_code}" "${URL}")
           if [ "${HTTP_CODE}" -eq 200 ]; then
             echo -e "Deployment successful!"
             exit


### PR DESCRIPTION
One webapp is having issues returing headers.  This change avoids pulling detailed information with curl, sidestepping the problem.