### PR TITLE
Feat/handle slashes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,9 @@ runs:
 
         echo imageStream=${IS} >> $GITHUB_OUTPUT
         echo deploymentConfig=${DC} >> $GITHUB_OUTPUT
-        echo url=${URL} >> $GITHUB_OUTPUT
+
+        # Removes any double slashles, e.g. inputs.verification_path
+        echo url=${URL} | sed 's // / g' >> $GITHUB_OUTPUT
 
     - name: Deploy
       shell: bash


### PR DESCRIPTION
There was a request to remove double slashes, since they're likely to show up using the verification_path parameter.  E.g. `route=google.ca/` and `path=/health` would create url=$route/$path=google.ca//health'.

Update: this is no longer just a request, since that extra slash has been failing workflows!