### PR TITLE
Update image repo

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -8,7 +8,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  repo_builds: bcgov/nr-quickstart-typescript
+  repo_builds: bcgov/quickstart-openshift
 
 jobs:
   deploys:


### PR DESCRIPTION
I renamed the QuickStart repo without updating here.  Fast-tracking to prevent blocking https://github.com/bcgov-nr/action-deployer-openshift/pull/28 any further.  Sorry @barrfalk!