### PR TITLE
feat: allow zap to create issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Testing has only been done with public containers on ghcr.io (GitHub Container R
     # Allow ZAProxy alerts to fail the workflow? [true/false]
     penetration_test_fail: false
 
+    # Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
+    penetration_test_issue: frontend
+
     # Bash array to diff for build triggering
     # Optional, defaults to nothing, which forces a build
     triggers: ('frontend/')
@@ -102,7 +105,7 @@ deploys:
 
 # Example, Matrix / Multiple Templates
 
-Deploy multiple templates in parallel.  This time penetration tests are enabled.  Runs on pull requests (PRs).
+Deploy multiple templates in parallel.  This time penetration tests are enabled and issues created.  Runs on pull requests (PRs).
 
 ```yaml
 deploys:
@@ -142,6 +145,7 @@ steps:
         -p COMMON_TEMPLATE_VAR=whatever-${{ github.event.number }}
         ${{ matrix.parameters }}
       penetration_test: true
+      penetration_test_issue: ${{ matrix.name }}
       triggers: ${{ matrix.triggers }}
 ```
 
@@ -174,7 +178,7 @@ deploys:
 
 Deployment templates are parsed for a route.  If found, those routes are verified with a curl command for status code 200 (success).  This ensures that applications are accessible from outside their OpenShift namespace/project.
 
-Provide `penetration_test: true` to instead run a penetration test using [OWASP ZAP (Zed Attack Proxy)](https://github.com/zaproxy/action-full-scan) against that route. `penetration_test_fail: false` can be used to fail pipelines where problems are found.
+Provide `penetration_test: true` to instead run a penetration test using [OWASP ZAP (Zed Attack Proxy)](https://github.com/zaproxy/action-full-scan) against that route. `penetration_test_fail: false` can be used to fail pipelines where problems are found.  `penetration_test_issue: name` creates issues and is generally preferable over failing pipelines.
 
 # Troubleshooting
 

--- a/action.yml
+++ b/action.yml
@@ -31,10 +31,7 @@ inputs:
     description: Allow ZAProxy alerts to fail the workflow? [true/false]
     default: "false"
   penetration_test_issue:
-    description: Allow ZAProxy to write issues with results
-    default: "false"
-  penetration_test_issue_title:
-    description: ZAProxy issue title, requires issue=true
+    description: Provide a name to enable ZAProxy issue creation; e.g. ${{ matrix.name }}, frontend, backend
     default: ""
   token:
     description: GitHub token
@@ -192,8 +189,9 @@ runs:
         target: https://${{ steps.vars.outputs.url }}
         cmd_options: "-a"
         fail_action: ${{ inputs.penetration_test_fail }}
-        allow_issue_writing: ${{ inputs.penetration_test_issue }}
-        issue_title: ${{ inputs.penetration_test_issue_title }}
+        # allow_... is purposefully obscured - if a title is provided, then = true
+        allow_issue_writing: ${{ inputs.penetration_test_issue && true || false }}
+        issue_title: "ZAP: ${{ inputs.penetration_test_issue }}"
         token: ${{ inputs.token }}
 
     # Action repo needs to be present for cleanup/tests

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
     description: Allow ZAProxy alerts to fail the workflow? [true/false]
     default: "false"
   penetration_test_issue:
-    description: Provide a name to enable ZAProxy issue creation; e.g. ${{ matrix.name }}, frontend, backend
+    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
     default: ""
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ inputs:
   penetration_test_fail:
     description: Allow ZAProxy alerts to fail the workflow? [true/false]
     default: "false"
+  penetration_test_issue:
+    description: Allow ZAProxy to write issues with results
+    default: "false"
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:
@@ -183,7 +186,7 @@ runs:
         target: https://${{ steps.vars.outputs.url }}
         cmd_options: "-a"
         fail_action: ${{ inputs.penetration_test_fail }}
-        allow_issue_writing: false
+        allow_issue_writing: ${{ inputs.penetration_test_issue }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   penetration_test_issue:
     description: Allow ZAProxy to write issues with results
     default: "false"
+  penetration_test_issue_title:
+    description: ZAProxy issue title, requires issue=true
+    default: ""
   token:
     description: GitHub token
     default: ""
@@ -190,6 +193,7 @@ runs:
         cmd_options: "-a"
         fail_action: ${{ inputs.penetration_test_fail }}
         allow_issue_writing: ${{ inputs.penetration_test_issue }}
+        issue_title: ${{ inputs.penetration_test_issue_title }}
         token: ${{ inputs.token }}
 
     # Action repo needs to be present for cleanup/tests

--- a/action.yml
+++ b/action.yml
@@ -33,9 +33,6 @@ inputs:
   penetration_test_issue:
     description: Provide a name to enable ZAProxy issue creation; e.g. ${{ matrix.name }}, frontend, backend
     default: ""
-  token:
-    description: GitHub token
-    default: ""
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:
@@ -192,7 +189,6 @@ runs:
         # allow_... is purposefully obscured - if a title is provided, then = true
         allow_issue_writing: ${{ inputs.penetration_test_issue && true || false }}
         issue_title: "ZAP: ${{ inputs.penetration_test_issue }}"
-        token: ${{ inputs.token }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: "false"
   token:
     description: GitHub token
-    default: ${{ secrets.GITHUB_TOKEN }}
+    default: ""
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   penetration_test_issue:
     description: Allow ZAProxy to write issues with results
     default: "false"
+  token:
+    description: GitHub token
+    default: ${{ secrets.GITHUB_TOKEN }}
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:
@@ -187,6 +190,7 @@ runs:
         cmd_options: "-a"
         fail_action: ${{ inputs.penetration_test_fail }}
         allow_issue_writing: ${{ inputs.penetration_test_issue }}
+        token: ${{ inputs.token }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)


### PR DESCRIPTION
Allow ZAProxy penetration tests to generate issues.  Providing a name to`penetration_test_issue` will enable issue writing.