### PR TITLE
feat: revise parameters, improve error handling and checks

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -13,7 +13,7 @@ jobs:
   # Clean up OpenShift when PR closed, no conditions
   cleanup-openshift:
     name: Cleanup OpenShift
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Remove OpenShift artifacts
         run: |

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -28,14 +28,14 @@ jobs:
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: true
-            # triggers: ('backend/')
+            triggers: ('backend/')
             verification_path: /api
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
-            penetration_test: true
-            # triggers: ('frontend/')
+            penetration_test: false
+            triggers: ('frontend/')
     steps:
       - uses: actions/checkout@v4
       - name: Deploys

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -48,8 +48,6 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           penetration_test: ${{ matrix.penetration_test }}
-          penetration_test_issue: true
-          penetration_test_token: ${{ secrets.GITHUB_TOKEN }}
           parameters:
             -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
             -p PROMOTE=${{ env.repo_builds }}/${{ matrix.name }}:test

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -48,6 +48,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           penetration_test: ${{ matrix.penetration_test }}
+          penetration_test_issue: true
           penetration_test_token: ${{ secrets.GITHUB_TOKEN }}
           parameters:
             -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -15,7 +15,7 @@ jobs:
     name: Deploys
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      issues: write
     strategy:
       matrix:
         name: [database, backend, frontend]

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -53,5 +53,4 @@ jobs:
             -p PROMOTE=${{ env.repo_builds }}/${{ matrix.name }}:test
             ${{ matrix.parameters }}
           repository: ${{ env.repo_builds }}
-          triggers: ${{ matrix.triggers }}
           verification_path: ${{ matrix.verification_path }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -15,7 +15,7 @@ jobs:
     name: Deploys
     runs-on: ubuntu-latest
     permissions:
-      packages: read
+      packages: write
     strategy:
       matrix:
         name: [database, backend, frontend]

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -14,8 +14,8 @@ jobs:
   deploys:
     name: Deploys
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
+    # permissions:
+    #   issues: write
     strategy:
       matrix:
         name: [database, backend, frontend]

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -28,14 +28,14 @@ jobs:
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: true
-            triggers: ('backend/')
+            # triggers: ('backend/')
             verification_path: /api
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: false
-            triggers: ('frontend/')
+            # triggers: ('frontend/') 
     steps:
       - uses: actions/checkout@v4
       - name: Deploys

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -14,8 +14,6 @@ jobs:
   deploys:
     name: Deploys
     runs-on: ubuntu-latest
-    # permissions:
-    #   issues: write
     strategy:
       matrix:
         name: [database, backend, frontend]
@@ -28,14 +26,12 @@ jobs:
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: true
-            # triggers: ('backend/')
             verification_path: /api
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: false
-            # triggers: ('frontend/') 
     steps:
       - uses: actions/checkout@v4
       - name: Deploys

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -27,8 +27,9 @@ jobs:
             file: backend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
+            penetration_test: true
             triggers: ('backend/')
-            verification_path: /
+            verification_path: /api
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
@@ -41,6 +42,7 @@ jobs:
         uses: ./
         with:
           file: ${{ matrix.file }}
+          name: ${{ matrix.name }}
           oc_namespace: ${{ secrets.OC_NAMESPACE }}
           oc_server: ${{ secrets.OC_SERVER }}
           oc_token: ${{ secrets.OC_TOKEN }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -48,6 +48,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           overwrite: ${{ matrix.overwrite }}
           penetration_test: ${{ matrix.penetration_test }}
+          penetration_test_token: ${{ secrets.GITHUB_TOKEN }}
           parameters:
             -p ZONE=${{ github.event.number }} -p NAME=${{ github.event.repository.name }}
             -p PROMOTE=${{ env.repo_builds }}/${{ matrix.name }}:test

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -28,14 +28,14 @@ jobs:
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: true
-            triggers: ('backend/')
+            # triggers: ('backend/')
             verification_path: /api
           - name: frontend
             file: frontend/openshift.deploy.yml
             overwrite: true
             parameters: -p MIN_REPLICAS=1 -p MAX_REPLICAS=2
             penetration_test: true
-            triggers: ('frontend/')
+            # triggers: ('frontend/')
     steps:
       - uses: actions/checkout@v4
       - name: Deploys
@@ -54,4 +54,5 @@ jobs:
             -p PROMOTE=${{ env.repo_builds }}/${{ matrix.name }}:test
             ${{ matrix.parameters }}
           repository: ${{ env.repo_builds }}
+          triggers: ${{ matrix.triggers }}
           verification_path: ${{ matrix.verification_path }}

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         fi
 
         # Deprecation notices
-        if [ ! -z ${{ inputs.penetration_test_artifact }}]||[ ! -z ${{ inputs.penetration_test_issue }}]; then
+        if [ ! -z ${{ inputs.penetration_test_artifact }} ]||[ ! -z ${{ inputs.penetration_test_issue }} ]; then
           echo -e "Params penetration_test_artifact and penetration_test_issue have been deprecated. \n"
           echo -e "Please use param: name instead.  Exiting.\n"
           exit 1

--- a/action.yml
+++ b/action.yml
@@ -106,14 +106,14 @@ runs:
 
         # Output URL (host + path), but only if ROUTE_HOST is populated
         ROUTE_HOST=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.host //empty")
-        ROUTE_PATH_INPUTS=${{ inputs.verification_path }}
-        ROUTE_PATH_TEMPLATE=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.path //empty")
         if [ ! -z ${ROUTE_HOST} ]; then
-          # Route path from inputs or template (inputs.verification_path takes priority over template)
-          ROUTE_PATH=${${ROUTE_PATH_INPUT}:-${ROUTE_PATH_TEMPLATE}}
-          URL_HOST_PATH="${ROUTE_HOST}/${ROUTE_PATH}"
+          # Path from inputs takes priority over template
+          ROUTE_PATH=${{ inputs.verification_path }}
+          [ ! -z ${ROUTE_PATH} ]|| \
+            ROUTE_PATH=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.path //empty")
 
           # Removes any duplicate slashes and pass to GITHUB_OUTPUT
+          URL_HOST_PATH="${ROUTE_HOST}/${ROUTE_PATH}"
           echo url=${URL_HOST_PATH} | sed 's // / g' >> $GITHUB_OUTPUT
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ inputs:
     required: true
 
   ### Typical / recommended
+  name:
+    description: Name that will be used in any issues artifacts; e.g. ZAP pen tests
   parameters:
     description: Template parameters/variables to pass (e.g. -p ZONE=...)
   penetration_test:
@@ -197,8 +199,9 @@ runs:
         fail_action: "${{ inputs.penetration_test_fail }}"
         # allow_... is purposefully obscured - if a title is provided, then = true
         allow_issue_writing: "${{ inputs.penetration_test_issue && true || false }}"
-        artifact_name: "zap_${{ inputs.penetration_test_artifact }}"
-        issue_title: "ZAP: ${{ inputs.penetration_test_issue }}"
+        artifact_name: "zap_${{ inputs.name }}"
+        issue_title: "ZAP: ${{ inputs.name }}"
+        token: ${{ inputs.penetratoin_test_token }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -23,33 +23,23 @@ inputs:
     required: true
 
   ### Typical / recommended
+  name:
+    description: Name that will be used in any issues artifacts; e.g. ZAP pen tests
   parameters:
-    description: Template parameters/variables to pass (e.g. -p ZONE=...)
+    description: Template parameters/variables to pass; e.g. -p ZONE=...
   penetration_test:
     description: Run a ZAProxy penetration test against any routes? [true|false]
-  penetration_test_fail:
-    description: Allow ZAProxy alerts to fail the workflow? [true|false]
-    default: "false"
-  penetration_test_artifact:
-    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
-    default: "unnamed"
-  penetration_test_issue:
-    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
-    default: ""
+  penetration_test_token:
+    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
+    default: ${{ github.token }}
   timeout:
     description: Timeout for deployment. [default=15m]
     default: "15m"
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:
-    description: Sets the health endpoint to be used during check stage, does not require the '/' at the begining
+    description: Sets the health endpoint to be used during verificatoin, does not require '/' at the begining; e.g. api
     default: ""
-  verification_retry_attempts:
-    description: Number of times to attempt deployment verification
-    default: "3"
-  verification_retry_seconds:
-    description: Seconds to wait between deployment verification attempts
-    default: "10"
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -58,9 +48,24 @@ inputs:
   repository:
     description: Optionally, specify a different repo to clone
     default: ${{ github.repository }}
-  penetration_test_token:
-    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
-    default: ${{ github.token }}
+  penetration_test_fail:
+    description: Allow ZAProxy alerts to fail the workflow? Caution, very annoying!  [true|false]
+    default: "false"
+  verification_retry_attempts:
+    description: Number of times to attempt deployment verification
+    default: "3"
+  verification_retry_seconds:
+    description: Seconds to wait between deployment verification attempts
+    default: "10"
+
+  ### Deprecated / to remove
+  # Both replaced by `penetration_test_name`, used for issues and artifacts
+  penetration_test_issue:
+    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
+    default: "unnamed"
+  penetration_test_artifact:
+    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
+    default: ""
 
 runs:
   using: composite
@@ -196,9 +201,9 @@ runs:
         cmd_options: "-a"
         fail_action: "${{ inputs.penetration_test_fail }}"
         # allow_... is purposefully obscured - if a title is provided, then = true
-        allow_issue_writing: "${{ inputs.penetration_test_issue && true || false }}"
-        artifact_name: "zap_${{ inputs.penetration_test_artifact }}"
-        issue_title: "ZAP: ${{ inputs.penetration_test_issue }}"
+        allow_issue_writing: "${{ inputs.name && true || false }}"
+        artifact_name: "zap_${{ inputs.name }}"
+        issue_title: "ZAP: ${{ inputs.name }}"
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -101,22 +101,21 @@ runs:
         # ImageStream, DeploymentConfig and Route Host from template
         DC=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"DeploymentConfig\").metadata.name //empty")
         IS=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"ImageStream\").metadata.name //empty")
-        ROUTE_HOST=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.host //empty")
-
-        # Route path from inputs or template (inputs.verification_path takes priority)
-        ROUTE_PATH=${{ inputs.verification_path }}
-        [ ! -z "${ROUTE_PATH}" ]|| \
-          ROUTE_PATH=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.path //empty")
-
-        # Build URL from route and path, but only if ROUTE_HOST is populated
-        [ -z "${ROUTE_HOST}" ]|| URL_HOST_PATH="${ROUTE_HOST}/${ROUTE_PATH}"
-
         echo imageStream=${IS} >> $GITHUB_OUTPUT
         echo deploymentConfig=${DC} >> $GITHUB_OUTPUT
 
-        # Removes any double slashles, e.g. inputs.verification_path
-        [ ! -z ${URL_HOST_PATH} ]|| \
+        # Output URL (host + path), but only if ROUTE_HOST is populated
+        ROUTE_HOST=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.host //empty")
+        ROUTE_PATH_INPUTS=${{ inputs.verification_path }}
+        ROUTE_PATH_TEMPLATE=$(jq -rn "${TEMPLATE} | .items[] | select(.kind==\"Route\").spec.path //empty")
+        if [ ! -z ${ROUTE_HOST} ]; then
+          # Route path from inputs or template (inputs.verification_path takes priority over template)
+          ROUTE_PATH=${${ROUTE_PATH_INPUT}:-${ROUTE_PATH_TEMPLATE}}
+          URL_HOST_PATH="${ROUTE_HOST}/${ROUTE_PATH}"
+
+          # Removes any duplicate slashes and pass to GITHUB_OUTPUT
           echo url=${URL_HOST_PATH} | sed 's // / g' >> $GITHUB_OUTPUT
+        fi
 
         # Triggers
         TRIGGERS=${{ inputs.triggers }}

--- a/action.yml
+++ b/action.yml
@@ -204,6 +204,7 @@ runs:
         allow_issue_writing: "${{ inputs.name && true || false }}"
         artifact_name: "zap_${{ inputs.name }}"
         issue_title: "ZAP: ${{ inputs.name }}"
+        token: ${{ inputs.penetration_test_token }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -175,8 +175,8 @@ runs:
         [ -z "${DC}" ]|| oc rollout status dc/${DC} -w
 
     - name: Route Verification
-      if: steps.vars.outputs.url && \
-        ( steps.vars.outputs.triggered == 'true' )&& \
+      if: steps.vars.outputs.url &&
+        ( steps.vars.outputs.triggered == 'true' )&&
         ( inputs.penetration_test != 'true' )
       shell: bash
       run: |
@@ -206,8 +206,8 @@ runs:
         exit 1
 
     - name: Penetration Test
-      if: steps.vars.outputs.url && \
-        ( steps.vars.outputs.triggered == 'true ')&& \
+      if: steps.vars.outputs.url &&
+        ( steps.vars.outputs.triggered == 'true' )&&
         ( inputs.penetration_test == 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
       with:

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   repository:
     description: Optionally, specify a different repo to clone
     default: ${{ github.repository }}
+  penetration_test_create_issue:
+    description: Create an issue with penetration test results?  [true|false]
+    default: "true"
   penetration_test_token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
@@ -204,13 +207,13 @@ runs:
       if: steps.vars.outputs.url && steps.vars.outputs.triggered &&( inputs.penetration_test == 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
       with:
-        target: https://${{ steps.vars.outputs.url }}
+        allow_issue_writing: "${{ inputs.penetration_test_create_issue }}"
+        artifact_name: "zap_${{ inputs.name }}"
         cmd_options: "-a"
         fail_action: "${{ inputs.penetration_test_fail }}"
-        allow_issue_writing: "${{ inputs.penetration_test }}"
-        artifact_name: "zap_${{ inputs.name }}"
         issue_title: "ZAP: ${{ inputs.name }}"
-        token: ${{ inputs.penetration_test_token }}
+        target: https://${{ steps.vars.outputs.url }}
+        token: "${{ inputs.penetration_test_token }}"
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -24,20 +24,16 @@ inputs:
 
   ### Typical / recommended
   name:
-    description: Name that will be used in any issues artifacts; e.g. ZAP pen tests
+    description: Name for any penetration test issues or artifacts; e.g. frontend
+    default: "name_unset"
   parameters:
     description: Template parameters/variables to pass (e.g. -p ZONE=...)
   penetration_test:
     description: Run a ZAProxy penetration test against any routes? [true|false]
+    default: "false"
   penetration_test_fail:
     description: Allow ZAProxy alerts to fail the workflow? [true|false]
     default: "false"
-  penetration_test_artifact:
-    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
-    default: "unnamed"
-  penetration_test_issue:
-    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
-    default: ""
   timeout:
     description: Timeout for deployment. [default=15m]
     default: "15m"
@@ -46,12 +42,6 @@ inputs:
   verification_path:
     description: Sets the health endpoint to be used during check stage, does not require the '/' at the begining
     default: ""
-  verification_retry_attempts:
-    description: Number of times to attempt deployment verification
-    default: "3"
-  verification_retry_seconds:
-    description: Seconds to wait between deployment verification attempts
-    default: "10"
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -63,6 +53,20 @@ inputs:
   penetration_test_token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
+  verification_retry_attempts:
+    description: Number of times to attempt deployment verification
+    default: "3"
+  verification_retry_seconds:
+    description: Seconds to wait between deployment verification attempts
+    default: "10"
+
+  ### Deprecated / to be removed
+  penetration_test_artifact:
+    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
+    default: "unnamed"
+  penetration_test_issue:
+    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
+    default: ""
 
 runs:
   using: composite
@@ -197,8 +201,7 @@ runs:
         target: https://${{ steps.vars.outputs.url }}
         cmd_options: "-a"
         fail_action: "${{ inputs.penetration_test_fail }}"
-        # allow_... is purposefully obscured - if a title is provided, then = true
-        allow_issue_writing: "${{ inputs.penetration_test_issue && true || false }}"
+        allow_issue_writing: "${{ inputs.penetration_test }}"
         artifact_name: "zap_${{ inputs.name }}"
         issue_title: "ZAP: ${{ inputs.name }}"
         token: ${{ inputs.penetration_test_token }}

--- a/action.yml
+++ b/action.yml
@@ -193,6 +193,11 @@ runs:
         echo -e "\nRoute verification failed"
         exit 1
 
+    # Action repo needs to be present for cleanup/tests
+    - name: Checkout to make sure action.yml is present (tests)
+      if: ${{ github.repository }} != ${{ inputs.repository }}
+      uses: actions/checkout@v4
+
     - name: Penetration Test
       if: steps.vars.outputs.url && steps.vars.outputs.triggered &&( inputs.penetration_test == 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
@@ -206,7 +211,3 @@ runs:
         issue_title: "ZAP: ${{ inputs.name }}"
         token: ${{ inputs.penetration_test_token }}
 
-    # Action repo needs to be present for cleanup/tests
-    - name: Checkout to make sure action.yml is present (tests)
-      if: ${{ github.repository }} != ${{ inputs.repository }}
-      uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -201,7 +201,7 @@ runs:
         allow_issue_writing: "${{ inputs.penetration_test_issue && true || false }}"
         artifact_name: "zap_${{ inputs.name }}"
         issue_title: "ZAP: ${{ inputs.name }}"
-        token: ${{ inputs.penetratoin_test_token }}
+        token: ${{ inputs.penetration_test_token }}
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,8 @@ runs:
         echo deploymentConfig=${DC} >> $GITHUB_OUTPUT
 
         # Removes any double slashles, e.g. inputs.verification_path
-        echo url=${URL_HOST_PATH} | sed 's // / g' >> $GITHUB_OUTPUT
+        [ -z ${URL_HOST_PATH} ]|| \
+          echo url=${URL_HOST_PATH} | sed 's // / g' >> $GITHUB_OUTPUT
 
         # Triggers
         TRIGGERS=${{ inputs.triggers }}

--- a/action.yml
+++ b/action.yml
@@ -60,13 +60,11 @@ inputs:
     description: Seconds to wait between deployment verification attempts
     default: "10"
 
-  ### Deprecated / to be removed
+  ### Deprecated
   penetration_test_artifact:
     description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
-    default: "unnamed"
   penetration_test_issue:
     description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
-    default: ""
 
 runs:
   using: composite
@@ -86,6 +84,13 @@ runs:
         if [[ $REPO != ${REPO,,} ]]; then
           echo -e "An OpenShift bug prevents capital letters in repo names.\n"
           echo -e "Please handle that using the `repository` parameter.\n"
+          exit 1
+        fi
+
+        # Deprecation notices
+        if [ ! -z ${{ inputs.penetration_test_artifact }}]||[ ! -z ${{ inputs.penetration_test_issue }}]; then
+          echo -e "Params penetration_test_artifact and penetration_test_issue have been deprecated. \n"
+          echo -e "Please use param: name instead.  Exiting.\n"
           exit 1
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -23,23 +23,33 @@ inputs:
     required: true
 
   ### Typical / recommended
-  name:
-    description: Name that will be used in any issues artifacts; e.g. ZAP pen tests
   parameters:
-    description: Template parameters/variables to pass; e.g. -p ZONE=...
+    description: Template parameters/variables to pass (e.g. -p ZONE=...)
   penetration_test:
     description: Run a ZAProxy penetration test against any routes? [true|false]
-  penetration_test_token:
-    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
-    default: ${{ github.token }}
+  penetration_test_fail:
+    description: Allow ZAProxy alerts to fail the workflow? [true|false]
+    default: "false"
+  penetration_test_artifact:
+    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
+    default: "unnamed"
+  penetration_test_issue:
+    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
+    default: ""
   timeout:
     description: Timeout for deployment. [default=15m]
     default: "15m"
   triggers:
     description: Omit to always build, otherwise trigger by path; e.g. ('./backend/', './frontend/)
   verification_path:
-    description: Sets the health endpoint to be used during verificatoin, does not require '/' at the begining; e.g. api
+    description: Sets the health endpoint to be used during check stage, does not require the '/' at the begining
     default: ""
+  verification_retry_attempts:
+    description: Number of times to attempt deployment verification
+    default: "3"
+  verification_retry_seconds:
+    description: Seconds to wait between deployment verification attempts
+    default: "10"
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -48,24 +58,9 @@ inputs:
   repository:
     description: Optionally, specify a different repo to clone
     default: ${{ github.repository }}
-  penetration_test_fail:
-    description: Allow ZAProxy alerts to fail the workflow? Caution, very annoying!  [true|false]
-    default: "false"
-  verification_retry_attempts:
-    description: Number of times to attempt deployment verification
-    default: "3"
-  verification_retry_seconds:
-    description: Seconds to wait between deployment verification attempts
-    default: "10"
-
-  ### Deprecated / to remove
-  # Both replaced by `penetration_test_name`, used for issues and artifacts
-  penetration_test_issue:
-    description: Provide a name to attach ZAProxy scan artifacts to workflows; e.g. frontend, backend
-    default: "unnamed"
-  penetration_test_artifact:
-    description: Provide a name to enable ZAProxy issue creation; e.g. frontend, backend
-    default: ""
+  penetration_test_token:
+    description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
+    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -193,11 +188,6 @@ runs:
         echo -e "\nRoute verification failed"
         exit 1
 
-    # Action repo needs to be present for cleanup/tests
-    - name: Checkout to make sure action.yml is present (tests)
-      if: ${{ github.repository }} != ${{ inputs.repository }}
-      uses: actions/checkout@v4
-
     - name: Penetration Test
       if: steps.vars.outputs.url && steps.vars.outputs.triggered &&( inputs.penetration_test == 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
@@ -206,8 +196,11 @@ runs:
         cmd_options: "-a"
         fail_action: "${{ inputs.penetration_test_fail }}"
         # allow_... is purposefully obscured - if a title is provided, then = true
-        allow_issue_writing: "${{ inputs.name && true || false }}"
-        artifact_name: "zap_${{ inputs.name }}"
-        issue_title: "ZAP: ${{ inputs.name }}"
-        token: ${{ inputs.penetration_test_token }}
+        allow_issue_writing: "${{ inputs.penetration_test_issue && true || false }}"
+        artifact_name: "zap_${{ inputs.penetration_test_artifact }}"
+        issue_title: "ZAP: ${{ inputs.penetration_test_issue }}"
 
+    # Action repo needs to be present for cleanup/tests
+    - name: Checkout to make sure action.yml is present (tests)
+      if: ${{ github.repository }} != ${{ inputs.repository }}
+      uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
         echo "Triggers not matched, deployment skipped"
 
     - name: Deploy
-      if: steps.vars.outputs.triggered === 'true'
+      if: steps.vars.outputs.triggered == 'true'
       shell: bash
       run: |
         # Expand for deployment steps
@@ -176,8 +176,8 @@ runs:
 
     - name: Route Verification
       if: steps.vars.outputs.url && \
-        ( steps.vars.outputs.triggered === 'true' )&& \
-        ( inputs.penetration_test !== 'true' )
+        ( steps.vars.outputs.triggered == 'true' )&& \
+        ( inputs.penetration_test != 'true' )
       shell: bash
       run: |
         # Expand for route verification
@@ -207,8 +207,8 @@ runs:
 
     - name: Penetration Test
       if: steps.vars.outputs.url && \
-        ( steps.vars.outputs.triggered === 'true ')&& \
-        ( inputs.penetration_test === 'true' )
+        ( steps.vars.outputs.triggered == 'true ')&& \
+        ( inputs.penetration_test == 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
       with:
         allow_issue_writing: "${{ inputs.penetration_test_create_issue }}"
@@ -221,5 +221,5 @@ runs:
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)
-      if: ${{ github.repository }} !== ${{ inputs.repository }}
+      if: ${{ github.repository }} != ${{ inputs.repository }}
       uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -115,7 +115,7 @@ runs:
         echo deploymentConfig=${DC} >> $GITHUB_OUTPUT
 
         # Removes any double slashles, e.g. inputs.verification_path
-        [ -z ${URL_HOST_PATH} ]|| \
+        [ ! -z ${URL_HOST_PATH} ]|| \
           echo url=${URL_HOST_PATH} | sed 's // / g' >> $GITHUB_OUTPUT
 
         # Triggers

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
         echo "Triggers not matched, deployment skipped"
 
     - name: Deploy
-      if: steps.vars.outputs.triggered
+      if: steps.vars.outputs.triggered === 'true'
       shell: bash
       run: |
         # Expand for deployment steps
@@ -175,7 +175,9 @@ runs:
         [ -z "${DC}" ]|| oc rollout status dc/${DC} -w
 
     - name: Route Verification
-      if: steps.vars.outputs.url && steps.vars.outputs.triggered &&( inputs.penetration_test != 'true' )
+      if: steps.vars.outputs.url && \
+        ( steps.vars.outputs.triggered === 'true' )&& \
+        ( inputs.penetration_test !== 'true' )
       shell: bash
       run: |
         # Expand for route verification
@@ -204,7 +206,9 @@ runs:
         exit 1
 
     - name: Penetration Test
-      if: steps.vars.outputs.url && steps.vars.outputs.triggered &&( inputs.penetration_test == 'true' )
+      if: steps.vars.outputs.url && \
+        ( steps.vars.outputs.triggered === 'true ')&& \
+        ( inputs.penetration_test === 'true' )
       uses: zaproxy/action-full-scan@v0.7.0
       with:
         allow_issue_writing: "${{ inputs.penetration_test_create_issue }}"
@@ -217,5 +221,5 @@ runs:
 
     # Action repo needs to be present for cleanup/tests
     - name: Checkout to make sure action.yml is present (tests)
-      if: ${{ github.repository }} != ${{ inputs.repository }}
+      if: ${{ github.repository }} !== ${{ inputs.repository }}
       uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,7 @@ runs:
       shell: bash
       run: |
         # Expand for inputs and variables
+        set -eu
 
         # Bug mitigation - OpenShift hates images with capitals in org/repo names
         REPO=${{ inputs.repository }}


### PR DESCRIPTION
- deprecate and instruct for `penetration_test_artifact`
- deprecate and instruct for `penetration_test_issue`
- new param `name` for app penetration test objects
- new param `penetration_test_token` for overriding the default token (e.g. P.A.T.)
- revise URL_HOST_PATH logic
- add `set -eu` for errors/stops
- improved conditionals/checks
- add issue creation to tests
- add `verification_path` to tests
- dial down required token permissions
- use runner `ubuntu-latest` consistently/exclusively