### PR TITLE
feat: update workflows

### DIFF
--- a/templates/backend.yml
+++ b/templates/backend.yml
@@ -15,7 +15,7 @@ parameters:
     value: ghcr.io
   - name: PROMOTE
     description: Image to promote
-    value: ghcr.io/bcgov/quickstart-openshift/backend:test
+    value: ghcr.io/bcgov/quickstart-openshift/backend:latest
   - name: IMAGE_TAG
     description: Image tag to use
     value: latest

--- a/templates/database.yml
+++ b/templates/database.yml
@@ -15,7 +15,7 @@ parameters:
     value: ghcr.io
   - name: PROMOTE
     description: Image to promote
-    value: ghcr.io/bcgov/nr-containers/postgres:15.4
+    value: ghcr.io/bcgov/nr-containers/postgres:15.5
   - name: IMAGE_TAG
     description: Image tag to use
     value: latest

--- a/templates/frontend.yml
+++ b/templates/frontend.yml
@@ -15,7 +15,7 @@ parameters:
     value: ghcr.io
   - name: PROMOTE
     description: Image to promote
-    value: ghcr.io/bcgov/quickstart-openshift/frontend:test
+    value: ghcr.io/bcgov/quickstart-openshift/frontend:latest
   - name: IMAGE_TAG
     description: Image tag to use
     value: latest


### PR DESCRIPTION
Workflows have gone stale since the QuickStart moved to Helm instead of OpenShift templates.  Update.

Resolves https://github.com/bcgov/quickstart-openshift/issues/1759.