### PR TITLE
fix: empty timeout param

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
         # Apply (overwrites) or create (does not overwrite) using processed template
         TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
         if [ "${{ inputs.overwrite }}" == "true" ]; then
-          oc apply --timeout=${{ inputs.timeout || "15m" }} -f - <<< "${TEMPLATE}"
+          oc apply --timeout=${{ inputs.timeout || '15m' }} -f - <<< "${TEMPLATE}"
         else
           # Suppress AlreadyExists errors and expected failure
           oc create -f - 2>&1 <<< "${TEMPLATE}" | sed 's/.*: //'

--- a/action.yml
+++ b/action.yml
@@ -176,7 +176,7 @@ runs:
         # Apply (overwrites) or create (does not overwrite) using processed template
         TEMPLATE="$(oc process -f ${{ inputs.file }} ${{ inputs.parameters }} --local)"
         if [ "${{ inputs.overwrite }}" == "true" ]; then
-          oc apply --timeout=${{ inputs.timeout }} -f - <<< "${TEMPLATE}"
+          oc apply --timeout=${{ inputs.timeout || "15m" }} -f - <<< "${TEMPLATE}"
         else
           # Suppress AlreadyExists errors and expected failure
           oc create -f - 2>&1 <<< "${TEMPLATE}" | sed 's/.*: //'


### PR DESCRIPTION
Empty timeout parameter should default to 10 minutes, not fail.