### PR TITLE
chore(deps): update dependency ubuntu to v24

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -15,7 +15,7 @@ jobs:
   cleanup-openshift:
     name: Cleanup OpenShift
     if: "!github.event.pull_request.head.repo.fork"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Remove OpenShift artifacts


### PR DESCRIPTION
This has known breaks.  I'm merging it anyway, because @paulushcgcj has a fix that's going in right after.  The juggling is happening to preserve his commits.