### PR TITLE
chore(ci): deploymentconfig deprecation

### DIFF
--- a/templates/backend.yml
+++ b/templates/backend.yml
@@ -28,6 +28,10 @@ parameters:
     value: "250m"
   - name: MEMORY_LIMIT_INIT
     value: "250Mi"
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
   - kind: Deployment
     apiVersion: apps/v1
@@ -70,6 +74,8 @@ objects:
                     secretKeyRef:
                       name: "${NAME}-${ZONE}-database"
                       key: database-user
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 3000
                   protocol: TCP
@@ -138,7 +144,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: 1
       maxReplicas: 2

--- a/templates/frontend.yml
+++ b/templates/frontend.yml
@@ -27,26 +27,29 @@ parameters:
     description: Random number, 0-60, for scheduling cronjobs
     from: "[0-5]{1}[0-9]{1}"
     generate: expression
+  - name: RANDOM_EXPRESSION
+    description: Random expression to make sure deployments update
+    from: "[a-zA-Z0-9]{32}"
+    generate: expression
 objects:
-  - apiVersion: v1
-    kind: DeploymentConfig
+  - kind: Deployment
+    apiVersion: apps/v1
     metadata:
       labels:
         app: "${NAME}-${ZONE}"
       name: "${NAME}-${ZONE}-${COMPONENT}"
     spec:
       replicas: 1
-      triggers:
-        - type: ConfigChange
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        matchLabels:
+          deployment: "${NAME}-${ZONE}-${COMPONENT}"
       strategy:
-        type: Rolling
+        type: RollingUpdate
       template:
         metadata:
           labels:
             app: "${NAME}-${ZONE}"
-            deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+            deployment: "${NAME}-${ZONE}-${COMPONENT}"
         spec:
           containers:
             - image: "ghcr.io/bcgov/quickstart-openshift/frontend:latest"
@@ -60,6 +63,8 @@ objects:
                   value: "https://${NAME}-${ZONE}-backend.${DOMAIN}:443"
                 - name: LOG_LEVEL
                   value: "${LOG_LEVEL}"
+                - name: RANDOM_EXPRESSION
+                  value: ${RANDOM_EXPRESSION}
               ports:
                 - containerPort: 3000
                   protocol: TCP
@@ -103,7 +108,7 @@ objects:
           port: 80
           targetPort: 3000
       selector:
-        deploymentconfig: "${NAME}-${ZONE}-${COMPONENT}"
+        deployment: "${NAME}-${ZONE}-${COMPONENT}"
   - apiVersion: route.openshift.io/v1
     kind: Route
     metadata:
@@ -128,7 +133,7 @@ objects:
     spec:
       scaleTargetRef:
         apiVersion: apps.openshift.io/v1
-        kind: DeploymentConfig
+        kind: Deployment
         name: "${NAME}-${ZONE}-${COMPONENT}"
       minReplicas: 1
       maxReplicas: 2


### PR DESCRIPTION
Replaces deprecated Deployment Configs with Deployments. Also removes image streams and uses a randomly generated envar to ensure consistent rollouts.

Unfortunately there will be some downtime when this deploys.

Steps:
- Delete deployment configs and services for TEST database and backend
- Delete deployment configs and services for PROD database and backend
- Merge this PR
- Let deployments to TEST and PROD complete