### PR TITLE
feat: lite_mode opt-out, improve PR detection

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -42,6 +42,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           oc_version: ${{ matrix.oc_version }}
           overwrite: ${{ matrix.overwrite }}
+          debug: true
           parameters: -p ZONE=${{ github.event.number }} ${{ matrix.parameters }}
       - id: trigger
         run: echo "${{ matrix.name }}=${{ steps.deploys.outputs.triggered }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -18,6 +18,7 @@ jobs:
       database: ${{ steps.trigger.outputs.database }}
       frontend: ${{ steps.trigger.outputs.frontend }}
     strategy:
+      fail-fast: false
       matrix:
         name: [ backend, database, frontend ]
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,3 @@ dist
 .tern-port
 
 # Misc
-.codebuddy/

--- a/action.yml
+++ b/action.yml
@@ -139,6 +139,8 @@ runs:
       shell: bash
       run: |
         # Apply lite mode modifications for pull requests
+        echo "DEBUG: Lite Mode is ENABLED (inputs.lite_mode=${{ inputs.lite_mode }})"
+        echo "DEBUG: Event Name is ${{ github.event_name }}"
         echo "Applying lite mode modifications"
         TEMPLATE=$(echo "${TEMPLATE}" | jq '
           del(.items[] | select(.kind=="HorizontalPodAutoscaler")) |

--- a/action.yml
+++ b/action.yml
@@ -56,9 +56,9 @@ inputs:
       Example: true, false
     default: ${{ github.event.pull_request != '' }}
     type: boolean
-  verbose:
+  debug:
     description: |
-      Enable verbose logging?
+      Enable debug logging?
       Example: true, false
     default: false
     type: boolean
@@ -145,7 +145,7 @@ runs:
       shell: bash
       run: |
         # Apply lite mode modifications for pull requests
-        if [ "${{ inputs.verbose }}" = "true" ]; then
+        if [ "${{ inputs.debug }}" = "true" ]; then
           echo "DEBUG: Template BEFORE lite mode modifications:"
           echo "${TEMPLATE}"
         fi
@@ -167,7 +167,7 @@ runs:
         echo "${TEMPLATE}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
 
-        if [ "${{ inputs.verbose }}" = "true" ]; then
+        if [ "${{ inputs.debug }}" = "true" ]; then
           echo "DEBUG: Template AFTER lite mode modifications:"
           echo "${TEMPLATE}"
         fi

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
       shell: bash
       run: |
         echo "---- CONTEXT DIAGNOSTICS ----"
-        echo "Event Name:  ${{ github.event_name }}"
+        echo "Event Name:   ${{ github.event_name }}"
         echo "Pull Request: ${{ github.event.pull_request != '' }}"
         echo "Base Ref:     ${{ github.base_ref }}"
         echo "Lite Mode:    ${{ inputs.lite_mode }}"

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,12 @@ inputs:
     description: |
       Omit to always build, otherwise trigger by path
       Example: ('./backend/', './frontend/)
+  lite_mode:
+    description: |
+      Apply 'lite mode' modifications (scaling down, removing PDBs) for pull requests?
+      Example: true, false
+    default: true
+    type: boolean
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -129,7 +135,7 @@ runs:
         # Bug mitigation - Docker hates images with capitals in org/repo names
         echo "REPOSITORY=$(echo "${{ inputs.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-    - if: github.event_name == 'pull_request' && steps.triggers.outputs.triggered == 'true'
+    - if: (github.event_name == 'pull_request' || github.event.pull_request) && inputs.lite_mode == 'true' && steps.triggers.outputs.triggered == 'true'
       shell: bash
       run: |
         # Apply lite mode modifications for pull requests

--- a/action.yml
+++ b/action.yml
@@ -153,15 +153,23 @@ runs:
           fi
 
           echo "Applying lite mode modifications"
-          TEMPLATE=$(echo "${TEMPLATE}" | jq '
+          echo "${TEMPLATE}" > .template.json
+          jq '
             .items |= map(select(.kind != "HorizontalPodAutoscaler" and .kind != "PodDisruptionBudget")) |
             .items |= map(
               if .kind == "Deployment"
               then .spec.replicas = 1 | .spec.strategy.type = "Recreate"
               else .
               end
-            )'
-          )
+            )' .template.json > .template_lite.json
+          
+          if [ -s .template_lite.json ]; then
+            TEMPLATE=$(cat .template_lite.json)
+          else
+            echo "::error::Failed to apply lite mode modifications (jq output was empty)"
+            exit 1
+          fi
+          rm .template.json .template_lite.json
 
           if [[ "${{ inputs.debug }}" == "true" ]]; then
             echo "DEBUG: Template AFTER lite mode modifications:"

--- a/action.yml
+++ b/action.yml
@@ -164,8 +164,7 @@ runs:
 
         echo "Applying lite mode modifications"
         TEMPLATE=$(echo "${TEMPLATE}" | jq '
-          del(.items[] | select(.kind=="HorizontalPodAutoscaler")) |
-          del(.items[] | select(.kind=="PodDisruptionBudget")) |
+          .items |= map(select(.kind != "HorizontalPodAutoscaler" and .kind != "PodDisruptionBudget")) |
           .items |= map(
             if .kind == "Deployment"
             then .spec.replicas = 1 | .spec.strategy.type = "Recreate"

--- a/action.yml
+++ b/action.yml
@@ -145,43 +145,34 @@ runs:
           oc delete imagestream ${name} --ignore-not-found
         done
 
+        # Apply lite mode modifications for pull requests if triggered
+        if [[ "${{ inputs.lite_mode }}" == "true" ]]; then
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
+            echo "DEBUG: Template BEFORE lite mode modifications:"
+            echo "${TEMPLATE}"
+          fi
+
+          echo "Applying lite mode modifications"
+          TEMPLATE=$(echo "${TEMPLATE}" | jq '
+            .items |= map(select(.kind != "HorizontalPodAutoscaler" and .kind != "PodDisruptionBudget")) |
+            .items |= map(
+              if .kind == "Deployment"
+              then .spec.replicas = 1 | .spec.strategy.type = "Recreate"
+              else .
+              end
+            )'
+          )
+
+          if [[ "${{ inputs.debug }}" == "true" ]]; then
+            echo "DEBUG: Template AFTER lite mode modifications:"
+            echo "${TEMPLATE}"
+          fi
+        fi
+
         # Store template in environment variable using heredoc format for multiline values
         echo "TEMPLATE<<EOF" >> $GITHUB_ENV
         echo "${TEMPLATE}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
-
-        # Bug mitigation - Docker hates images with capitals in org/repo names
-        echo "REPOSITORY=$(echo "${{ inputs.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-    - if: inputs.lite_mode && steps.triggers.outputs.triggered == 'true'
-      shell: bash
-      run: |
-        # Apply lite mode modifications for pull requests
-        if [ "${{ inputs.debug }}" = "true" ]; then
-          echo "DEBUG: Template BEFORE lite mode modifications:"
-          echo "${TEMPLATE}"
-        fi
-
-        echo "Applying lite mode modifications"
-        TEMPLATE=$(echo "${TEMPLATE}" | jq '
-          .items |= map(select(.kind != "HorizontalPodAutoscaler" and .kind != "PodDisruptionBudget")) |
-          .items |= map(
-            if .kind == "Deployment"
-            then .spec.replicas = 1 | .spec.strategy.type = "Recreate"
-            else .
-            end
-          )'
-        )
-
-        # Store template in environment variable using heredoc format for multiline values
-        echo "TEMPLATE<<EOF" >> $GITHUB_ENV
-        echo "${TEMPLATE}" >> $GITHUB_ENV
-        echo "EOF" >> $GITHUB_ENV
-
-        if [ "${{ inputs.debug }}" = "true" ]; then
-          echo "DEBUG: Template AFTER lite mode modifications:"
-          echo "${TEMPLATE}"
-        fi
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     description: |
       Apply 'lite mode' modifications (scaling down, removing PDBs) for pull requests?
       Example: true, false
-    default: ${{ github.event_name == 'pull_request' || github.event.pull_request != '' }}
+    default: ${{ github.event.pull_request != '' }}
     type: boolean
 
   ### Usually a bad idea / not recommended

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,18 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Context Diagnostics
+      if: inputs.debug
+      shell: bash
+      run: |
+        echo "---- CONTEXT DIAGNOSTICS ----"
+        echo "Event Name:  ${{ github.event_name }}"
+        echo "Pull Request: ${{ github.event.pull_request != '' }}"
+        echo "Base Ref:     ${{ github.base_ref }}"
+        echo "Lite Mode:    ${{ inputs.lite_mode }}"
+        echo "Debug Mode:   ${{ inputs.debug }}"
+        echo "---------------------------"
+
     # Send triggers to diff action
     - id: triggers
       uses: bcgov/action-diff-triggers@4abfcb211f5816d654d1c5a417e5431a2c4a5379 # v1.1.1

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,12 @@ inputs:
       Example: true, false
     default: ${{ github.event.pull_request != '' }}
     type: boolean
+  verbose:
+    description: |
+      Enable verbose logging?
+      Example: true, false
+    default: false
+    type: boolean
 
   ### Usually a bad idea / not recommended
   diff_branch:
@@ -135,12 +141,15 @@ runs:
         # Bug mitigation - Docker hates images with capitals in org/repo names
         echo "REPOSITORY=$(echo "${{ inputs.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-    - if: inputs.lite_mode == 'true' && steps.triggers.outputs.triggered == 'true'
+    - if: inputs.lite_mode && steps.triggers.outputs.triggered == 'true'
       shell: bash
       run: |
         # Apply lite mode modifications for pull requests
-        echo "DEBUG: Lite Mode is ENABLED (inputs.lite_mode=${{ inputs.lite_mode }})"
-        echo "DEBUG: Event Name is ${{ github.event_name }}"
+        if [ "${{ inputs.verbose }}" = "true" ]; then
+          echo "DEBUG: Template BEFORE lite mode modifications:"
+          echo "${TEMPLATE}"
+        fi
+
         echo "Applying lite mode modifications"
         TEMPLATE=$(echo "${TEMPLATE}" | jq '
           del(.items[] | select(.kind=="HorizontalPodAutoscaler")) |
@@ -157,6 +166,11 @@ runs:
         echo "TEMPLATE<<EOF" >> $GITHUB_ENV
         echo "${TEMPLATE}" >> $GITHUB_ENV
         echo "EOF" >> $GITHUB_ENV
+
+        if [ "${{ inputs.verbose }}" = "true" ]; then
+          echo "DEBUG: Template AFTER lite mode modifications:"
+          echo "${TEMPLATE}"
+        fi
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     description: |
       Apply 'lite mode' modifications (scaling down, removing PDBs) for pull requests?
       Example: true, false
-    default: true
+    default: ${{ github.event_name == 'pull_request' || github.event.pull_request != '' }}
     type: boolean
 
   ### Usually a bad idea / not recommended
@@ -135,7 +135,7 @@ runs:
         # Bug mitigation - Docker hates images with capitals in org/repo names
         echo "REPOSITORY=$(echo "${{ inputs.repository }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
-    - if: (github.event_name == 'pull_request' || github.event.pull_request) && inputs.lite_mode == 'true' && steps.triggers.outputs.triggered == 'true'
+    - if: inputs.lite_mode == 'true' && steps.triggers.outputs.triggered == 'true'
       shell: bash
       run: |
         # Apply lite mode modifications for pull requests


### PR DESCRIPTION
## Summary
This PR improves the 'Lite Mode' functionality by adding an explicit opt-out and making pull request detection more robust for reusable workflows. It also includes minor repository housekeeping.

### Changes
- **New Input**: Added `lite_mode` (default: `true`). Setting this to `false` allows developers to bypass automated scaling/stripping modifications in PRs.
- **Robust PR Detection**: Updated the conditional logic to check for `github.event.pull_request`. This ensures that Lite Mode is correctly applied when the action is called from a reusable workflow triggered by a PR (where `github.event_name` might be `workflow_call`).
- **Housekeeping**: Removed `.codebuddy/` from `.gitignore`.

### Why?
Currently, some PR deployments are leaking full production resources (5+ replicas) because the action fails to identify the PR context in nested workflows. This fix ensures resource efficiency by default while providing an escape hatch for complex testing scenarios.