### PR TITLE
feat: support private repos

### DIFF
--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -10,7 +10,8 @@ concurrency:
   group: pr-${{ github.workflow }}-${{ github.event.number }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   # Clean up OpenShift when PR closed, no conditions
@@ -24,6 +25,7 @@ jobs:
           oc_namespace: ${{ vars.oc_namespace }}
           oc_token: ${{ secrets.oc_token }}
           oc_server: ${{ vars.oc_server }}
+          token: ${{ github.token }}
           commands: |
             # Remove old build runs, build pods and deployment pods
             oc delete all,pvc,secret -l app=${{ github.event.repository.name }}-${{ github.event.number }}

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -7,7 +7,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   deploys:

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,11 @@ inputs:
       Example: bcgov/quickstart-openshift
     default: ${{ github.repository }}
     pattern: "^[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+$"
+  token:
+    description: |
+      GitHub token to use for private repositories
+      Default: ${{ github.token }}
+    default: ${{ github.token }}
 
 outputs:
   triggered:
@@ -107,6 +112,7 @@ runs:
       with:
         triggers: ${{ inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch }}
+        token: ${{ inputs.token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -117,6 +123,7 @@ runs:
         oc_version: ${{ inputs.oc_version }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
+        token: ${{ inputs.token }}
 
     - if: inputs.oc_version == '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -126,6 +133,7 @@ runs:
         oc_server: ${{ inputs.oc_server }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
+        token: ${{ inputs.token }}
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash
@@ -205,3 +213,5 @@ runs:
     - name: Checkout local repo to make sure action.yml is present
       if: github.repository != inputs.repository
       uses: actions/checkout@v6
+      with:
+        token: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -82,8 +82,8 @@ inputs:
     pattern: "^[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+$"
   token:
     description: |
-      GitHub token to use for private repositories
-      Default: ${{ github.token }}
+      Specify token (GH or PAT), instead of inheriting one from the calling workflow
+    default: ${{ github.token }}
 
 outputs:
   triggered:
@@ -111,7 +111,7 @@ runs:
       with:
         triggers: ${{ inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch }}
-        token: ${{ inputs.token || github.token }}
+        token: ${{ inputs.token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -122,7 +122,7 @@ runs:
         oc_version: ${{ inputs.oc_version }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token || github.token }}
+        token: ${{ inputs.token }}
 
     - if: inputs.oc_version == '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -132,7 +132,7 @@ runs:
         oc_server: ${{ inputs.oc_server }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token || github.token }}
+        token: ${{ inputs.token }}
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash
@@ -213,4 +213,4 @@ runs:
       if: github.repository != inputs.repository
       uses: actions/checkout@v6
       with:
-        token: ${{ inputs.token || github.token }}
+        token: ${{ inputs.token }}

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,6 @@ inputs:
     description: |
       GitHub token to use for private repositories
       Default: ${{ github.token }}
-    default: ${{ github.token }}
 
 outputs:
   triggered:
@@ -112,7 +111,7 @@ runs:
       with:
         triggers: ${{ inputs.triggers }}
         diff_branch: ${{ inputs.diff_branch }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token || github.token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -123,7 +122,7 @@ runs:
         oc_version: ${{ inputs.oc_version }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token || github.token }}
 
     - if: inputs.oc_version == '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -133,7 +132,7 @@ runs:
         oc_server: ${{ inputs.oc_server }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token || github.token }}
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash
@@ -214,4 +213,4 @@ runs:
       if: github.repository != inputs.repository
       uses: actions/checkout@v6
       with:
-        token: ${{ inputs.token }}
+        token: ${{ inputs.token || github.token }}


### PR DESCRIPTION
This PR adds support for private repositories by:
- Adding a `token` input to `action.yml` (defaulting to `${{ github.token }}`).
- Passing the `token` to `bcgov/action-diff-triggers` and `bcgov/action-oc-runner`.
- Passing the `token` to the final `actions/checkout` step.
- Updating workflow permissions to `contents: read` to allow cloning in private repos.

Closes #160