### PR TITLE
fix(inputs): switch optional input to github_token; bump runner and trigger actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,11 +107,11 @@ runs:
 
     # Send triggers to diff action
     - id: triggers
-      uses: bcgov/action-diff-triggers@9be6baaf718f92cfa66c89fe6d286207d5bba8f1 # v1.2.0
+      uses: bcgov/action-diff-triggers@a80e4b3cf77b7e05f84e74030e3bfa08b717a574 # v1.2.1
       with:
         triggers: ${{ inputs.triggers }}
         ref: ${{ inputs.ref }}
-        token: ${{ inputs.github_token }}
+        github_token: ${{ inputs.github_token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ runs:
         github_token: ${{ inputs.github_token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
-      uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
+      uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
       with:
         oc_namespace: ${{ inputs.oc_namespace }}
         oc_token: ${{ inputs.oc_token }}
@@ -122,17 +122,17 @@ runs:
         oc_version: ${{ inputs.oc_version }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.github_token }}
+        github_token: ${{ inputs.github_token }}
 
     - if: inputs.oc_version == '' && steps.triggers.outputs.triggered == 'true'
-      uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
+      uses: bcgov/action-oc-runner@b1c55b8a8bd5f42b19f72e6ea7df6d6a6eda44a1 # v1.5.1
       with:
         oc_namespace: ${{ inputs.oc_namespace }}
         oc_token: ${{ inputs.oc_token }}
         oc_server: ${{ inputs.oc_server }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.github_token }}
+        github_token: ${{ inputs.github_token }}
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ inputs:
       Example: bcgov/quickstart-openshift
     default: ${{ github.repository }}
     pattern: "^[a-zA-Z0-9-_]+/[a-zA-Z0-9-_]+$"
-  token:
+  github_token:
     description: |
       Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
@@ -111,7 +111,7 @@ runs:
       with:
         triggers: ${{ inputs.triggers }}
         ref: ${{ inputs.ref }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
 
     - if: inputs.oc_version != '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -122,7 +122,7 @@ runs:
         oc_version: ${{ inputs.oc_version }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
 
     - if: inputs.oc_version == '' && steps.triggers.outputs.triggered == 'true'
       uses: bcgov/action-oc-runner@1815ce17a815c71e9078851a2e3da84d191ea6c3 # v1.5.0
@@ -132,7 +132,7 @@ runs:
         oc_server: ${{ inputs.oc_server }}
         repository: ${{ inputs.repository }}
         triggers: ${{ inputs.triggers }}
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}
 
     - if: steps.triggers.outputs.triggered == 'true'
       shell: bash
@@ -213,4 +213,4 @@ runs:
       if: github.repository != inputs.repository
       uses: actions/checkout@v6
       with:
-        token: ${{ inputs.token }}
+        token: ${{ inputs.github_token }}


### PR DESCRIPTION
This PR renames the 'token' input parameter to 'github_token' to align with standard GitHub Actions conventions and avoid naming ambiguity.  Updates related actions, since this is a cascading change.